### PR TITLE
null to connect

### DIFF
--- a/{{cookiecutter.component_name}}/index.js
+++ b/{{cookiecutter.component_name}}/index.js
@@ -20,7 +20,7 @@ const
 	</div>;
 
 export default compose(
-	connect()
+	connect(null)
 )({{cookiecutter.component_name}});
 {% else %}
 
@@ -32,6 +32,6 @@ const
 };
 
 export default compose(
-	connect()
+	connect(null)
 )({{cookiecutter.component_name}});
 {% endif -%}


### PR DESCRIPTION
Добавляет аргумент `null` в `connect()`, без этого при импорте созданного в reacto компонента он `undefined`